### PR TITLE
Readme update, quick start error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To get started, simply install ardoqpy, create an ArdoqClient object and call me
 
 or from the console
 
-    from ardoqpy import ArdoqClient
+    import ardoqpy
     ardoq = ardoqpy.ArdoqClient(hosturl='https://YOURORG.ardoq.com', token='YOURTOKEN')
     ardoq.get_workspaces()
 


### PR DESCRIPTION
the quick start python code has an error

```
    from ardoqpy import ArdoqClient
    ardoq = ardoqpy.ArdoqClient(hosturl='https://YOURORG.ardoq.com', token='YOURTOKEN')
```

returns

```
Traceback (most recent call last):
  File "ardoqtouch.py", line 2, in <module>
    ardoq = ardoqpy.ArdoqClient(hosturl=host, token=token)
NameError: name 'ardoqpy' is not defined
```

due to import mismatch

import with namespace is often preferred in examples over `from ardoqpy import` for clarity of code